### PR TITLE
Refactor cf-abacus-broker

### DIFF
--- a/lib/cf/broker/src/auth/oauth.js
+++ b/lib/cf/broker/src/auth/oauth.js
@@ -9,20 +9,28 @@ const edebug = require('abacus-debug')('e-metering-broker');
 
 const systemToken = oauth.cache(config.uris().cf_api,
   process.env.SERVICE_BROKER_CLIENT_ID,
-  process.env.SERVICE_BROKER_CLIENT_SECRET,
-  'clients.write clients.admin');
+  process.env.SERVICE_BROKER_CLIENT_SECRET, 'clients.write clients.admin');
 
 const init = () => {
-  systemToken.start((err) => {
-    if (err)
-      edebug('Could not fetch OAuth token %o', err);
-  });
-  debug('Started OAuth system token from %o authentication server',
-    config.uris().cf_api);
+  if(process.env.SERVICE_BROKER_CLIENT_ID &&
+    process.env.SERVICE_BROKER_CLIENT_SECRET) {
+    debug('Fetching OAuth system token from server %o', config.uris().cf_api);
+    systemToken.start((err) => {
+      if (err) {
+        edebug('Could not fetch OAuth token %o', err);
+        debug('Could not fetch OAuth token %o', err);
+      }
+      else
+        debug('Successfully fetched OAuth token from %s', config.uris().cf_api);
+    });
+  }
+  else
+    throw new Error('SERVICE_BROKER credentials are not supplied');
 };
 
 const authHeader = () => {
-  return { authorization: systemToken() };
+  let token = systemToken();
+  return token ? { authorization: token } : undefined;
 };
 
 module.exports.init = init;

--- a/lib/cf/broker/src/auth/oauth.js
+++ b/lib/cf/broker/src/auth/oauth.js
@@ -12,20 +12,19 @@ const systemToken = oauth.cache(config.uris().cf_api,
   process.env.SERVICE_BROKER_CLIENT_SECRET, 'clients.write clients.admin');
 
 const init = () => {
-  if(process.env.SERVICE_BROKER_CLIENT_ID &&
-    process.env.SERVICE_BROKER_CLIENT_SECRET) {
-    debug('Fetching OAuth system token from server %o', config.uris().cf_api);
-    systemToken.start((err) => {
-      if (err) {
-        edebug('Could not fetch OAuth token %o', err);
-        debug('Could not fetch OAuth token %o', err);
-      }
-      else
-        debug('Successfully fetched OAuth token from %s', config.uris().cf_api);
-    });
-  }
-  else
+  if(!process.env.SERVICE_BROKER_CLIENT_ID &&
+    !process.env.SERVICE_BROKER_CLIENT_SECRET)
     throw new Error('SERVICE_BROKER credentials are not supplied');
+
+  debug('Fetching OAuth system token from server %o', config.uris().cf_api);
+  systemToken.start((err) => {
+    if (err) {
+      edebug('Could not fetch OAuth token %o', err);
+      debug('Could not fetch OAuth token %o', err);
+    }
+    else
+      debug('Successfully fetched OAuth token from %s', config.uris().cf_api);
+  });
 };
 
 const authHeader = () => {

--- a/lib/cf/broker/src/auth/uaa.js
+++ b/lib/cf/broker/src/auth/uaa.js
@@ -27,13 +27,13 @@ const edebug = require('abacus-debug')('e-metering-broker');
 const createClient = (instanceId, cb) => {
   const scopes = ['abacus.usage.' + instanceId + '.read',
     'abacus.usage.' + instanceId + '.write'];
-
-  const clientId = 'abacus-rp-' + instanceId;
+  const clientId = config.prefixWithResourceProvider(instanceId);
   const secret = generator.generate({
     length: 10,
     numbers: true
   });
 
+  debug('Creating UAA client with id %s ', clientId);
   request.post(config.uris().uaa_server + '/oauth/clients', {
     headers: oauth.authHeader(),
     body: {
@@ -47,20 +47,24 @@ const createClient = (instanceId, cb) => {
     }
   }, (err, res) => {
     if(err) {
-      edebug('Could not create UAA client %o', err);
+      edebug('Could not create UAA client %s due to  %o', clientId, err);
+      debug('Could not create UAA client %s due to  %o', clientId, err);
       cb(httpStatus.INTERNAL_SERVER_ERROR, {});
     }
     else if (res.statusCode !== httpStatus.CREATED) {
-      debug('Could not create UAA client. UAA returned: ', res.statusCode);
+      edebug('Could not create UAA client %s due to %o ',
+        clientId, res.statusCode);
+      debug('Could not create UAA client %s due to %o ',
+        clientId, res.statusCode);
       cb(res.statusCode, {});
     }
     else {
-      debug('Successfully created UAA client');
+      debug('Successfully created UAA client %s', clientId);
       cb(res.statusCode, {
         credentials: {
           client_id: clientId,
           client_secret: secret,
-          collector_url: config.uris().collector,
+          collector_url: config.uris().collector + config.usageCollectorPath,
           dashboard_url: ''
         }
       });
@@ -69,29 +73,30 @@ const createClient = (instanceId, cb) => {
 };
 
 const deleteClient = (instanceId, cb) => {
-  const clientId = 'abacus-rp-' + instanceId;
-  debug('Deleting UAA client id %o', clientId);
+  const clientId = config.prefixWithResourceProvider(instanceId);
 
+  debug('Deleting UAA client with id %s', clientId);
   request.delete(config.uris().uaa_server + '/oauth/clients/' + clientId, {
     headers: oauth.authHeader()
   }, (err, res) => {
     if(err) {
-      edebug('Could not delete UAA client from authorization server due to %o',
-        err);
+      edebug('Could not delete UAA client due to %o', err);
+      debug('Could not delete UAA client due to %o', err);
       cb(httpStatus.INTERNAL_SERVER_ERROR);
     }
     else if (res.statusCode == httpStatus.NOT_FOUND) {
-      debug('UAA client not found on authorization server');
+      debug('UAA client %s not found', clientId);
       cb(httpStatus.OK);
     }
     else if (res.statusCode == httpStatus.OK) {
-      debug('Successfully deleted UAA client from authorization server',
-        res.statusCode);
+      debug('Successfully deleted UAA client %s', clientId);
       cb(res.statusCode);
     }
     else {
-      debug('Could not delete UAA client from authorization server, status ' +
-        'code returned %o', res.statusCode);
+      edebug('Could not delete UAA client %s due to %s, %o',
+        res.statusCode, res.body);
+      debug('Could not delete UAA client %s due to %s, %o',
+        res.statusCode, res.body);
       cb(res.statusCode);
     }
   });

--- a/lib/cf/broker/src/config.js
+++ b/lib/cf/broker/src/config.js
@@ -13,6 +13,7 @@ const uris = memoize(() => urienv({
 }));
 
 const DEFAULT_USAGE_COLLECTOR_PATH = '/v1/metering/collected/usage';
+
 const usageCollectorPath = process.env.USAGE_COLLECTOR_PATH
   || DEFAULT_USAGE_COLLECTOR_PATH;
 
@@ -20,9 +21,12 @@ const DEFAULT_RESOURCE_PROVIDER_PREFIX = 'abacus-rp-';
 const prefixWithResourceProvider =
   (id = '') => DEFAULT_RESOURCE_PROVIDER_PREFIX + id;
 
+const DEFAULT_PLAN_NAME = 'standard';
+
 module.exports.uris = uris;
 module.exports.prefixWithResourceProvider = prefixWithResourceProvider;
 module.exports.DEFAULT_RESOURCE_PROVIDER_PREFIX =
   DEFAULT_RESOURCE_PROVIDER_PREFIX;
 module.exports.usageCollectorPath = usageCollectorPath;
 module.exports.DEFAULT_USAGE_COLLECTOR_PATH = DEFAULT_USAGE_COLLECTOR_PATH;
+module.exports.DEFAULT_PLAN_NAME = DEFAULT_PLAN_NAME;

--- a/lib/cf/broker/src/config.js
+++ b/lib/cf/broker/src/config.js
@@ -6,10 +6,23 @@ const memoize = _.memoize;
 const urienv = require('abacus-urienv');
 
 const uris = memoize(() => urienv({
-  cf_api : 9882,
+  cf_api: 9882,
   uaa_server: 9883,
   provisioning: 9880,
   collector: 9080
 }));
 
+const DEFAULT_USAGE_COLLECTOR_PATH = '/v1/metering/collected/usage';
+const usageCollectorPath = process.env.USAGE_COLLECTOR_PATH
+  || DEFAULT_USAGE_COLLECTOR_PATH;
+
+const DEFAULT_RESOURCE_PROVIDER_PREFIX = 'abacus-rp-';
+const prefixWithResourceProvider =
+  (id = '') => DEFAULT_RESOURCE_PROVIDER_PREFIX + id;
+
 module.exports.uris = uris;
+module.exports.prefixWithResourceProvider = prefixWithResourceProvider;
+module.exports.DEFAULT_RESOURCE_PROVIDER_PREFIX =
+  DEFAULT_RESOURCE_PROVIDER_PREFIX;
+module.exports.usageCollectorPath = usageCollectorPath;
+module.exports.DEFAULT_USAGE_COLLECTOR_PATH = DEFAULT_USAGE_COLLECTOR_PATH;

--- a/lib/cf/broker/src/plans/metering.js
+++ b/lib/cf/broker/src/plans/metering.js
@@ -1,19 +1,20 @@
 'use strict';
 
-module.exports = {
-  plan_id: '',
-  measures: [
-    {
-      name: 'sampleName',
-      unit: 'sampleUnit'
-    }
-  ],
-  metrics: [
-    {
-      name: 'sampleName',
-      unit: 'sampleUnit',
-      type: 'sampleType'
-    }
-  ]
+module.exports = (planId = '') => {
+  return {
+    plan_id: planId,
+    measures: [
+      {
+        name: 'sampleName',
+        unit: 'sampleUnit'
+      }
+    ],
+    metrics: [
+      {
+        name: 'sampleName',
+        unit: 'sampleUnit',
+        type: 'sampleType'
+      }
+    ]
+  };
 };
-

--- a/lib/cf/broker/src/plans/pricing.js
+++ b/lib/cf/broker/src/plans/pricing.js
@@ -1,16 +1,18 @@
 'use strict';
 
-module.exports = {
-  plan_id: '',
-  metrics: [
-    {
-      name: 'sampleName',
-      prices: [
-        {
-          country: 'sampleCountry',
-          price: 0
-        }
-      ]
-    }
-  ]
+module.exports = (planId = '') => {
+  return {
+    plan_id: planId,
+    metrics: [
+      {
+        name: 'sampleName',
+        prices: [
+          {
+            country: 'sampleCountry',
+            price: 0
+          }
+        ]
+      }
+    ]
+  };
 };

--- a/lib/cf/broker/src/plans/rating.js
+++ b/lib/cf/broker/src/plans/rating.js
@@ -1,10 +1,12 @@
 'use strict';
 
-module.exports = {
-  plan_id: '',
-  metrics: [
-    {
-      name: 'sampleName'
-    }
-  ]
+module.exports = (planId = '') => {
+  return {
+    plan_id: planId,
+    metrics: [
+      {
+        name: 'sampleName'
+      }
+    ]
+  };
 };

--- a/lib/cf/broker/src/routes/create-service.js
+++ b/lib/cf/broker/src/routes/create-service.js
@@ -33,7 +33,7 @@ const generatePlanId = (resourceProviderId, planId) => {
   return `${resourceProviderId}-${planId}`;
 };
 
-const createPlan = (resourceType, planBody, instanceId, cb) => {
+const createPlan = (resourceType, planBody, planId, cb) => {
   request.post(':provisioning_url/v1/:resource_type/plans', {
     provisioning_url: config.uris().provisioning,
     resource_type: resourceType,
@@ -42,18 +42,17 @@ const createPlan = (resourceType, planBody, instanceId, cb) => {
   }, (err) => {
     if (err) {
       edebug('Failed to create %s plan with id %s due to %o',
-        resourceType, instanceId, err);
+        resourceType, planId, err);
       cb(err);
     }
     else {
-      debug('Created %s plan with id %s', resourceType, instanceId);
-      cb(null, instanceId);
+      debug('Created %s plan with id %s', resourceType, planId);
+      cb(null, planId);
     }
   });
 };
 
-const createMapping = (resourceType, instanceId, cb) => {
-  const planId = generatePlanId(instanceId, instanceId);
+const createMapping = (resourceType, planId, instanceId, cb) => {
   request.post(':provisioning_url/v1/provisioning/mappings/:resource_type' +
     '/resources/:resource_id/plans/:plan_name/:plan_id', {
       provisioning_url: config.uris().provisioning,
@@ -65,51 +64,48 @@ const createMapping = (resourceType, instanceId, cb) => {
     }, (err) => {
       if (err) {
         edebug('Failed to create %s mapping with id %s due to %o',
-          resourceType, instanceId, err);
+          resourceType, planId, err);
         cb(err);
       }
       else {
-        debug('Created %s mapping with id %s', resourceType, instanceId);
-        cb(null, instanceId);
+        debug('Created %s mapping with id %s', resourceType, planId);
+        cb(null, instanceId, planId);
       }
     });
 };
 
-const createMeteringPlan = (instanceId, cb) => {
-  createPlan('metering', sampleMeteringPlan(generatePlanId(instanceId,
-    instanceId)), instanceId, cb);
+const createMeteringPlan = (planId, cb) => {
+  createPlan('metering', sampleMeteringPlan(planId), planId, cb);
 };
 
-const createPricingPlan = (instanceId, cb) => {
-  createPlan('pricing', samplePricingPlan(generatePlanId(instanceId,
-    instanceId)), instanceId, cb);
+const createPricingPlan = (planId, cb) => {
+  createPlan('pricing', samplePricingPlan(planId), planId, cb);
 };
 
-const createRatingPlan = (instanceId, cb) => {
-  createPlan('rating', sampleRatingPlan(generatePlanId(instanceId,
-    instanceId)), instanceId, cb);
+const createRatingPlan = (planId, cb) => {
+  createPlan('rating', sampleRatingPlan(planId), planId, cb);
 };
 
-const createMeteringPlanMapping = (instanceId, cb) => {
-  createMapping('metering', instanceId, cb);
+const createMeteringPlanMapping = (instanceId, planId, cb) => {
+  createMapping('metering', planId, instanceId, cb);
 };
 
-const createPricingPlanMapping = (instanceId, cb) => {
-  createMapping('pricing', instanceId, cb);
+const createPricingPlanMapping = (instanceId, planId, cb) => {
+  createMapping('pricing', planId, instanceId, cb);
 };
 
-const createRatingPlanMapping = (instanceId, cb) => {
-  createMapping('rating', instanceId, cb);
+const createRatingPlanMapping = (instanceId, planId, cb) => {
+  createMapping('rating', planId, instanceId, cb);
 };
 
 const createPlans = (instanceId, instanceName, cb) => {
   debug('Creating service instance %o with id %o', instanceName, instanceId);
-
+  const planId = generatePlanId(instanceId, instanceId);
   async.waterfall([
-    async.apply(createMeteringPlan, instanceId),
+    async.apply(createMeteringPlan, planId),
     createPricingPlan,
     createRatingPlan,
-    createMeteringPlanMapping,
+    async.apply(createMeteringPlanMapping, instanceId),
     createPricingPlanMapping,
     createRatingPlanMapping
   ], (err) => {

--- a/lib/cf/broker/src/routes/create-service.js
+++ b/lib/cf/broker/src/routes/create-service.js
@@ -60,7 +60,7 @@ const createMapping = (resourceType, instanceId, cb) => {
       resource_type: resourceType,
       resource_id: instanceId,
       plan_id: planId,
-      plan_name: planId,
+      plan_name: config.DEFAULT_PLAN_NAME,
       headers: oauth.authHeader()
     }, (err) => {
       if (err) {

--- a/lib/cf/broker/src/routes/create-service.js
+++ b/lib/cf/broker/src/routes/create-service.js
@@ -30,7 +30,7 @@ const throttleLimit = process.env.THROTTLE ? parseInt(process.env.THROTTLE) :
 const request = throttle(retry(breaker(abacusRequest)), throttleLimit);
 
 const generatePlanId = (resourceProviderId, planId) => {
-  return `resource_provider-${resourceProviderId}-plan-${planId}`;
+  return `${resourceProviderId}-${planId}`;
 };
 
 const createPlan = (resourceType, planBody, instanceId, cb) => {
@@ -53,12 +53,14 @@ const createPlan = (resourceType, planBody, instanceId, cb) => {
 };
 
 const createMapping = (resourceType, instanceId, cb) => {
+  const planId = generatePlanId(instanceId, instanceId);
   request.post(':provisioning_url/v1/provisioning/mappings/:resource_type' +
-    '/resources/:resource_id/plans/basic/:plan_id', {
+    '/resources/:resource_id/plans/:plan_name/:plan_id', {
       provisioning_url: config.uris().provisioning,
       resource_type: resourceType,
-      resource_id: generatePlanId(instanceId, instanceId),
-      plan_id: generatePlanId(instanceId, instanceId),
+      resource_id: instanceId,
+      plan_id: planId,
+      plan_name: planId,
       headers: oauth.authHeader()
     }, (err) => {
       if (err) {

--- a/lib/cf/broker/src/routes/create-service.js
+++ b/lib/cf/broker/src/routes/create-service.js
@@ -29,6 +29,9 @@ const throttleLimit = process.env.THROTTLE ? parseInt(process.env.THROTTLE) :
 // multiplied by the batch.
 const request = throttle(retry(breaker(abacusRequest)), throttleLimit);
 
+const generatePlanId = (resourceProviderId, planId) => {
+  return `resource_provider/${resourceProviderId}/plan/${planId}`;
+};
 
 const createPlan = (resourceType, planBody, instanceId, cb) => {
   request.post(':provisioning_url/v1/:resource_type/plans', {
@@ -49,14 +52,13 @@ const createPlan = (resourceType, planBody, instanceId, cb) => {
   });
 };
 
-
 const createMapping = (resourceType, instanceId, cb) => {
   request.post(':provisioning_url/v1/provisioning/mappings/:resource_type' +
     '/resources/:resource_id/plans/basic/:plan_id', {
       provisioning_url: config.uris().provisioning,
       resource_type: resourceType,
-      resource_id: instanceId,
-      plan_id: instanceId,
+      resource_id: generatePlanId(instanceId, instanceId),
+      plan_id: generatePlanId(instanceId, instanceId),
       headers: oauth.authHeader()
     }, (err) => {
       if (err) {
@@ -71,23 +73,19 @@ const createMapping = (resourceType, instanceId, cb) => {
     });
 };
 
-const generatePlanId = (resourceProviderId, planId) => {
-  return `resource_provider/${resourceProviderId}/plan/${planId}`;
-};
-
 const createMeteringPlan = (instanceId, cb) => {
-  sampleMeteringPlan.plan_id = generatePlanId(instanceId, instanceId);
-  createPlan('metering', sampleMeteringPlan, instanceId, cb);
+  createPlan('metering', sampleMeteringPlan(generatePlanId(instanceId,
+    instanceId)), instanceId, cb);
 };
 
 const createPricingPlan = (instanceId, cb) => {
-  samplePricingPlan.plan_id = generatePlanId(instanceId, instanceId);
-  createPlan('pricing', samplePricingPlan, instanceId, cb);
+  createPlan('pricing', samplePricingPlan(generatePlanId(instanceId,
+    instanceId)), instanceId, cb);
 };
 
 const createRatingPlan = (instanceId, cb) => {
-  sampleRatingPlan.plan_id = generatePlanId(instanceId, instanceId);
-  createPlan('rating', sampleRatingPlan, instanceId, cb);
+  createPlan('rating', sampleRatingPlan(generatePlanId(instanceId,
+    instanceId)), instanceId, cb);
 };
 
 const createMeteringPlanMapping = (instanceId, cb) => {
@@ -128,3 +126,4 @@ const createService = (req, res) => {
 
 module.exports = createService;
 module.exports.createPlans = createPlans;
+module.exports.generatePlanId = generatePlanId;

--- a/lib/cf/broker/src/routes/create-service.js
+++ b/lib/cf/broker/src/routes/create-service.js
@@ -30,7 +30,7 @@ const throttleLimit = process.env.THROTTLE ? parseInt(process.env.THROTTLE) :
 const request = throttle(retry(breaker(abacusRequest)), throttleLimit);
 
 const generatePlanId = (resourceProviderId, planId) => {
-  return `resource_provider/${resourceProviderId}/plan/${planId}`;
+  return `resource_provider-${resourceProviderId}-plan-${planId}`;
 };
 
 const createPlan = (resourceType, planBody, instanceId, cb) => {

--- a/lib/cf/broker/src/test/config-test.js
+++ b/lib/cf/broker/src/test/config-test.js
@@ -1,0 +1,36 @@
+'use strict';
+
+let config = require('../config.js');
+
+describe('Config', () => {
+  it('should set a prefix to a parameter specified', () => {
+    const id = '123';
+    expect(config.prefixWithResourceProvider(id))
+      .to.equal(`${config.DEFAULT_RESOURCE_PROVIDER_PREFIX}${id}`);
+  });
+
+  it('should return the prefix when there is no parameter specified', () => {
+    expect(config.prefixWithResourceProvider())
+      .to.equal(config.DEFAULT_RESOURCE_PROVIDER_PREFIX);
+  });
+
+  context('knows about usage collector path', () => {
+    beforeEach(() => {
+      delete process.env.USAGE_COLLECTOR_PATH;
+      delete require.cache[require.resolve('../config.js')];
+    });
+
+    it('should read it form the environment', () => {
+      const path = '/some/path';
+      process.env.USAGE_COLLECTOR_PATH = path;
+      config = require('../config.js');
+      expect(config.usageCollectorPath).to.equal(path);
+    });
+
+    it('should return default when no varaible is exported',() => {
+      config = require('../config.js');
+      expect(config.usageCollectorPath)
+        .to.equal(config.DEFAULT_USAGE_COLLECTOR_PATH);
+    });
+  });
+});

--- a/lib/cf/broker/src/test/create-test.js
+++ b/lib/cf/broker/src/test/create-test.js
@@ -19,7 +19,8 @@ describe('Create service instance', () => {
 
   const testPlanId = 'testPlanId';
   const instanceName = 'testInstanceName';
-  const formattedPlanId = `resource_provider/${testPlanId}/plan/${testPlanId}`;
+  const formattedPlanId = require('../routes/create-service.js')
+    .generatePlanId(testPlanId, testPlanId);
 
   beforeEach(() => {
     delete require.cache[require.resolve('abacus-request')];
@@ -41,40 +42,7 @@ describe('Create service instance', () => {
     createService = require('../routes/create-service.js');
   });
 
-
-
-  const sampleMeteringPlan = {
-    plan_id: formattedPlanId,
-    measures:[{
-      name:'sampleName',
-      unit:'sampleUnit'
-    }],
-    metrics:[{
-      name: 'sampleName',
-      unit:'sampleUnit',
-      type:'sampleType'
-    }]
-  };
-
-  const samplePricingPlan = {
-    plan_id: formattedPlanId,
-    metrics: [{
-      name: 'sampleName',
-      prices: [{
-        country: 'sampleCountry',
-        price: 0
-      }]
-    }]
-  };
-
-  const sampleRatingPlan = {
-    plan_id: formattedPlanId,
-    metrics: [{
-      name: 'sampleName'
-    }]
-  };
-
-  context('when 500 error occurs during plan creation', (done) => {
+  context('when error code 500 is retured during plan creation', (done) => {
     beforeEach(() => {
       errorCode = httpStatus.INTERNAL_SERVER_ERROR;
       errorMessage = 'Error';
@@ -102,39 +70,59 @@ describe('Create service instance', () => {
       });
     });
 
-    it('metering plan should be created', () => {
-      expect(postSpy.getCalls()[0].args[1].body)
-        .to.deep.equal(sampleMeteringPlan);
-    });
+    const meteringRequestParameters = {
+      plan_id: formattedPlanId,
+      resource_id: formattedPlanId
+    };
 
-    it('pricing plan should be created', () => {
-      expect(postSpy.getCalls()[1].args[1].body)
-        .to.deep.equal(samplePricingPlan);
-    });
+    const sampleMeteringPlan = {
+      plan_id: formattedPlanId,
+      measures:[{
+        name:'sampleName',
+        unit:'sampleUnit'
+      }],
+      metrics:[{
+        name: 'sampleName',
+        unit:'sampleUnit',
+        type:'sampleType'
+      }]
+    };
 
-    it('rating plan should be created', () => {
-      expect(postSpy.getCalls()[2].args[1].body)
-        .to.deep.equal(sampleRatingPlan);
-    });
+    const samplePricingPlan = {
+      plan_id: formattedPlanId,
+      metrics: [{
+        name: 'sampleName',
+        prices: [{
+          country: 'sampleCountry',
+          price: 0
+        }]
+      }]
+    };
 
-    it('metering mapping should be created', () => {
-      expect(postSpy.getCalls()[3].args[1].resource_id)
-        .to.equal(testPlanId);
-      expect(postSpy.getCalls()[3].args[1].plan_id).to.equal(testPlanId);
-    });
+    const sampleRatingPlan = {
+      plan_id: formattedPlanId,
+      metrics: [{
+        name: 'sampleName'
+      }]
+    };
 
-    it('metering pricing should be created', () => {
-      expect(postSpy.getCalls()[4].args[1].resource_id)
-        .to.equal(testPlanId);
-      expect(postSpy.getCalls()[4].args[1].plan_id).to.equal(testPlanId);
-    });
+    const itShouldCreate = (name, callIndex, requestParameters) => {
+      it(`${name} should be created`, () => {
+        expect(postSpy.getCall(callIndex).calledWithMatch(sinon.match.any,
+          requestParameters)).to.equal(true);
+      });
+    };
 
-    it('metering rating should be created', () => {
-      expect(postSpy.getCalls()[5].args[1].resource_id)
-        .to.equal(testPlanId);
-      expect(postSpy.getCalls()[5].args[1].plan_id).to.equal(testPlanId);
+    [ { 'metering plan': { body: sampleMeteringPlan } },
+      { 'pricing plan': { body: samplePricingPlan } },
+      { 'rating plan': { body: sampleRatingPlan } },
+      { 'metering mapping': meteringRequestParameters },
+      { 'pricing mapping': meteringRequestParameters },
+      { 'rating mapping': meteringRequestParameters }
+    ].forEach((value, idx) => {
+      let name = Object.keys(value)[0];
+      itShouldCreate(name, idx, value[name]);
     });
-
   });
 
   context('when 409 error occurs during plan creation', () => {

--- a/lib/cf/broker/src/test/create-test.js
+++ b/lib/cf/broker/src/test/create-test.js
@@ -72,7 +72,8 @@ describe('Create service instance', () => {
 
     const meteringRequestParameters = {
       plan_id: formattedPlanId,
-      resource_id: formattedPlanId
+      resource_id: testPlanId,
+      plan_name: formattedPlanId
     };
 
     const sampleMeteringPlan = {

--- a/lib/cf/broker/src/test/create-test.js
+++ b/lib/cf/broker/src/test/create-test.js
@@ -3,6 +3,7 @@
 const _ = require('underscore');
 const extend = _.extend;
 const httpStatus = require('http-status-codes');
+const config = require('../config.js');
 
 require('abacus-retry');
 require.cache[require.resolve('abacus-retry')].exports = (fn) => fn;
@@ -73,7 +74,7 @@ describe('Create service instance', () => {
     const meteringRequestParameters = {
       plan_id: formattedPlanId,
       resource_id: testPlanId,
-      plan_name: formattedPlanId
+      plan_name: config.DEFAULT_PLAN_NAME
     };
 
     const sampleMeteringPlan = {

--- a/lib/cf/broker/src/test/oauth-test.js
+++ b/lib/cf/broker/src/test/oauth-test.js
@@ -1,37 +1,72 @@
 'use strict';
 
-// Mock the oauth module
-require('abacus-oauth');
-let i = 0;
-const oauthCacheSpy = spy(() => () => ++i);
-require.cache[require.resolve('abacus-oauth')].exports.cache = oauthCacheSpy;
-require.cache[require.resolve('abacus-oauth')].exports.start = (cb) => cb();
+const _ = require('underscore');
+const extend = _.extend;
+const abacusOauth = require('abacus-oauth');
 
-const config = require('../config.js');
+let oauth = require('../auth/oauth.js');
 
-let oauth;
+// Mock abacus-debug
+const loggerSpy = spy((arg) => arg);
+require.cache[require.resolve('abacus-debug')].exports = spy(() => loggerSpy);
 
-describe('OAuth helper', () => {
-  before(() => {
-    process.env.SERVICE_BROKER_CLIENT_ID = 'id';
-    process.env.SERVICE_BROKER_CLIENT_SECRET = 'secret';
-    oauth = require('../auth/oauth.js');
-  });
-
-  it('uses the correct url, credentials and scope', () => {
-    expect(oauthCacheSpy.callCount).to.equal(1);
-    assert.calledWith(oauthCacheSpy,
-      config.uris().cf_api, 'id', 'secret',
-      'clients.write clients.admin'
-    );
-  });
-
-  it('returns a token on each request', () => {
-    expect(oauth.authHeader()).to.deep.equal({
-      authorization: 1
+describe('Oauth', () => {
+  context('when reading credentials from the environment', () => {
+    it('should fail when they are not set', () => {
+      delete process.env.SERVICE_BROKER_CLIENT_ID;
+      delete process.env.SERVICE_BROKER_CLIENT_SECRET;
+      expect(oauth.init).to.throw(Error);
     });
-    expect(oauth.authHeader()).to.deep.equal({
-      authorization: 2
+  });
+
+  context('when credentials are valid', () => {
+    const sampleToken = 'Bearer AAA';
+
+    const mockAbacusOauth = (cacheResult, cacheStartCallbackResult) => {
+      const abacusOauthCacheSpy = spy(() => cacheResult);
+      abacusOauthCacheSpy.start = spy((cb) => cb(cacheStartCallbackResult));
+      const abacusOauthMock = extend({}, abacusOauth, {
+        cache: () => abacusOauthCacheSpy
+      });
+      require.cache[require.resolve('abacus-oauth')].exports = abacusOauthMock;
+      // reload oauth module to resolve the mock
+      delete require.cache[require.resolve('../auth/oauth.js')];
+      oauth = require('../auth/oauth.js');
+      return abacusOauthCacheSpy;
+    };
+
+    beforeEach(() => {
+      process.env.SERVICE_BROKER_CLIENT_ID = 'valid';
+      process.env.SERVICE_BROKER_CLIENT_SECRET = 'secret';
+    });
+
+    it('should return an authorization header', () => {
+      const abacusOauthSpy = mockAbacusOauth(sampleToken, undefined);
+
+      expect(oauth.init).to.not.throw(Error);
+      expect(oauth.authHeader())
+        .to.deep.equal({ authorization: sampleToken });
+      expect(abacusOauthSpy.called).to.equal(true);
+      expect(abacusOauthSpy.start.called).to.equal(true);
+      expect(loggerSpy.calledWithMatch('Successfully fetched'));
+    });
+
+    it('should return a token on each request', () => {
+      const abacusOauthSpy = mockAbacusOauth(sampleToken, undefined);
+
+      for (let callCount of [1, 2]) {
+        expect(oauth.authHeader())
+          .to.deep.equal({ authorization: sampleToken });
+        expect(abacusOauthSpy.callCount).to.equal(callCount);
+      }
+    });
+
+    it('should log at least edebug messages in case of error', () => {
+      mockAbacusOauth(undefined, 'some error');
+
+      expect(oauth.init).to.not.throw(Error);
+      expect(oauth.authHeader()).to.be.equal(undefined);
+      expect(loggerSpy.calledWithMatch('Could not fetch')).to.equal(true);
     });
   });
 });

--- a/lib/cf/broker/src/test/uaa-test.js
+++ b/lib/cf/broker/src/test/uaa-test.js
@@ -4,6 +4,7 @@ const _ = require('underscore');
 const extend = _.extend;
 
 const httpStatus = require('http-status-codes');
+const config = require('../config.js');
 
 require('abacus-retry');
 require.cache[require.resolve('abacus-retry')].exports = (fn) => fn;
@@ -50,12 +51,16 @@ describe('UAA Helper', () => {
       expect(response.credentials.client_secret).not.to.equal(null);
       expect(response.credentials.reporting).not.to.equal(null);
       expect(response.credentials.dashboard_uri).not.to.equal(null);
-      expect(response.credentials.client_id).to.equal('abacus-rp-' +
-        instanceId);
-
+      expect(response.credentials.collector_url)
+        .to.include(config.uris().collector);
+      expect(response.credentials.collector_url)
+        .to.include(config.usageCollectorPath);
+      expect(response.credentials.client_id)
+        .to.equal(config.prefixWithResourceProvider(instanceId));
       expect(postSpy.callCount).to.equal(1);
       const body = postSpy.args[0][1].body;
-      expect(body.client_id).to.equal('abacus-rp-' + instanceId);
+      expect(body.client_id)
+        .to.equal(config.prefixWithResourceProvider(instanceId));
       expect(body.client_secret).not.to.equal(null);
       done();
     });

--- a/test/provisioning/package.json
+++ b/test/provisioning/package.json
@@ -26,6 +26,7 @@
   "main": "src/index.js",
   "scripts": {
     "itest": "eslint && mocha",
+    "test": "eslint",
     "lint": "eslint",
     "pub": "publish"
   },


### PR DESCRIPTION
- create plan mappings based on the new generated id
- extract common constants and configuration options to config module
- workaround missing npm test script in provisioning itest
- create samplePlans with given id
- reduce duplications in create-service tests
- fail to init oauth module when there are no credentials supplied
- improve debug messages

Signed-off-by: Stoyan Gradev <stoyan.gradev@sap.com>