### PR TITLE
Fix test app buildpack to specific version

### DIFF
--- a/test/broker/src/test/app-utils/test-app/manifest.yml
+++ b/test/broker/src/test/app-utils/test-app/manifest.yml
@@ -1,6 +1,7 @@
 ---
 applications:
 - name: abacus-broker-test-app
+  buildpack: https://github.com/cloudfoundry/nodejs-buildpack.git#v1.6.1
   command: node app.js
   memory: 128M
   instances: 1

--- a/test/broker/src/test/app-utils/test-app/package.json
+++ b/test/broker/src/test/app-utils/test-app/package.json
@@ -8,10 +8,6 @@
     "express": "4.15.5",
     "request-debug": "^0.2.0"
   },
-  "engines": {
-    "node": "8.2.1",
-    "npm": "5.3.0"
-  },
   "scripts": {
     "start": "node app.js"
   }


### PR DESCRIPTION
Having a specific version in the package.json without specifying a buildpack will lead to failures on CF installations that have a default buildpack that might not contain the needed versions. 
Since Abacus currently runs with v1.6.1 I am fixing the same buildpack to the test app. It will be revisited once the current performance problems (disabled snapshots) with node 8 are solved.