### PR TITLE
Introduce configurable list of scopes in oauth

### DIFF
--- a/lib/cf/broker/package.json
+++ b/lib/cf/broker/package.json
@@ -44,6 +44,7 @@
     "abacus-retry": "file:../../../abacus/lib/utils/retry",
     "abacus-request": "file:../../../abacus/lib/utils/request",
     "abacus-router": "file:../../../abacus/lib/utils/router",
+    "abacus-transform": "file:../../../abacus/lib/utils/transform",
     "abacus-throttle": "file:../../../abacus/lib/utils/throttle",
     "abacus-urienv": "file:../../../abacus/lib/utils/urienv",
     "abacus-webapp": "file:../../../abacus/lib/utils/webapp",

--- a/lib/cf/broker/src/auth/oauth.js
+++ b/lib/cf/broker/src/auth/oauth.js
@@ -1,24 +1,42 @@
 'use strict';
 
+const _ = require('underscore');
+const mapObject = _.mapObject;
+
 const oauth = require('abacus-oauth');
+const tmap = require('abacus-transform').map;
+const debug = require('abacus-debug')('abacus-broker');
 
 const config = require('../config.js');
 
-const debug = require('abacus-debug')('abacus-broker');
+const CLIENT_REGISTRATION_TOKEN = 'client_registration';
+const SYSTEM_TOKEN = 'system';
 
-const systemToken = oauth.cache(config.uris().api,
-  process.env.SERVICE_BROKER_CLIENT_ID,
-  process.env.SERVICE_BROKER_CLIENT_SECRET, 'clients.write clients.admin');
-
-const init = (cb) => {
-  debug('Fetching OAuth system token from server %o', config.uris().api);
-  systemToken.start(cb);
+const tokensToFetch = {
+  [SYSTEM_TOKEN]: process.env.SERVICE_BROKER_CLIENT_SCOPES ||
+    'abacus.usage.read abacus.usage.write',
+  [CLIENT_REGISTRATION_TOKEN]: 'clients.admin'
 };
 
-const authHeader = () => {
-  let token = systemToken();
-  return token ? { authorization: token } : undefined;
+const cachedTokens = mapObject(tokensToFetch, (scopes) =>
+  oauth.cache(config.uris().api,
+    process.env.SERVICE_BROKER_CLIENT_ID,
+    process.env.SERVICE_BROKER_CLIENT_SECRET, scopes));
+
+const init = (callback) => {
+  debug('Fetching OAuth system token from server %o', config.uris().api);
+  tmap(Object.keys(cachedTokens),
+    (tokenKey, index, list, cb) => cachedTokens[tokenKey].start(
+      (err) => err ? cb(err) : cb(undefined, 'successfully fetched')),
+    callback);
+};
+
+const authHeader = (token = SYSTEM_TOKEN) => {
+  const encodedToken = cachedTokens[token]();
+  return encodedToken ? { authorization: encodedToken } : undefined;
 };
 
 module.exports.init = init;
 module.exports.authHeader = authHeader;
+module.exports.CLIENT_REGISTRATION_TOKEN = CLIENT_REGISTRATION_TOKEN;
+module.exports.SYSTEM_TOKEN = SYSTEM_TOKEN;

--- a/lib/cf/broker/src/auth/uaa.js
+++ b/lib/cf/broker/src/auth/uaa.js
@@ -34,7 +34,7 @@ const createClient = (clientId, resourceId, cb) => {
 
   debug('Creating UAA client with id %s ', clientId);
   request.post(config.uris().auth_server + '/oauth/clients', {
-    headers: oauth.authHeader(),
+    headers: oauth.authHeader(oauth.CLIENT_REGISTRATION_TOKEN),
     body: {
       scope : scopes,
       client_id : clientId,
@@ -70,7 +70,7 @@ const createClient = (clientId, resourceId, cb) => {
 const deleteClient = (clientId, cb) => {
   debug('Deleting UAA client with id %s', clientId);
   request.delete(config.uris().auth_server + '/oauth/clients/' + clientId, {
-    headers: oauth.authHeader()
+    headers: oauth.authHeader(oauth.CLIENT_REGISTRATION_TOKEN)
   }, (err, res) => {
     if(err) {
       edebug('Could not delete UAA client %s due to %o', clientId, err);

--- a/lib/cf/broker/src/test/oauth-test.js
+++ b/lib/cf/broker/src/test/oauth-test.js
@@ -17,6 +17,8 @@ describe('Oauth', () => {
   const client = 'client';
   const secret = 'secret';
 
+  let oauth;
+
   after(() => sandbox.restore());
 
   afterEach(() => sandbox.reset());
@@ -26,17 +28,16 @@ describe('Oauth', () => {
     const token1 = 'Bearer AAA';
     const token2 = 'Bearer BBB';
 
-    beforeEach(() => {
+    before(() => {
       process.env.SERVICE_BROKER_CLIENT_ID = client;
       process.env.SERVICE_BROKER_CLIENT_SECRET = secret;
       process.env.SERVICE_BROKER_CLIENT_SCOPES = scopes;
+
+      oauthStub.returns(wrapperStub);
+      oauth = reloadOauthModule();
     });
 
     it('should call abacus oauth with the corresponding arguments', () => {
-      oauthStub.returns(wrapperStub);
-
-      reloadOauthModule();
-
       expect(oauthStub.callCount).to.equal(2);
       assert.calledWith(oauthStub, sinon.match.any, client, secret, scopes);
       assert.calledWith(oauthStub, sinon.match.any, client, secret,
@@ -47,9 +48,6 @@ describe('Oauth', () => {
       wrapperStub.start.yields();
       wrapperStub.onFirstCall().returns(token1);
       wrapperStub.onSecondCall().returns(token2);
-      oauthStub.returns(wrapperStub);
-
-      const oauth = reloadOauthModule();
 
       oauth.init((err) => {
         expect(err).to.equal(undefined);
@@ -64,9 +62,6 @@ describe('Oauth', () => {
     it('should return system token by default', (done) => {
       wrapperStub.start.yields();
       wrapperStub.onFirstCall().returns(token1);
-      oauthStub.returns(wrapperStub);
-
-      const oauth = reloadOauthModule();
 
       oauth.init((err) => {
         expect(err).to.equal(undefined);
@@ -77,9 +72,6 @@ describe('Oauth', () => {
 
     it('should throw with invalid token identifier', (done) => {
       wrapperStub.start.yields();
-      oauthStub.returns(wrapperStub);
-
-      const oauth = reloadOauthModule();
 
       oauth.init((err) => {
         expect(err).to.equal(undefined);
@@ -91,10 +83,6 @@ describe('Oauth', () => {
     it('should proxy the actual error from oauth', (done) => {
       const errorMessage = 'some_error';
       wrapperStub.start.yields(new Error(errorMessage));
-
-      oauthStub.returns(wrapperStub);
-
-      const oauth = reloadOauthModule();
 
       oauth.init((err) => {
         expect(err).to.be.instanceOf(Error);
@@ -109,7 +97,6 @@ describe('Oauth', () => {
       process.env.SERVICE_BROKER_CLIENT_ID = client;
       process.env.SERVICE_BROKER_CLIENT_SECRET = secret;
       delete process.env.SERVICE_BROKER_CLIENT_SCOPES;
-      oauthStub.returns(wrapperStub);
 
       reloadOauthModule();
 

--- a/lib/cf/broker/src/test/oauth-test.js
+++ b/lib/cf/broker/src/test/oauth-test.js
@@ -1,74 +1,122 @@
 'use strict';
 
-const _ = require('underscore');
-const extend = _.extend;
 const abacusOauth = require('abacus-oauth');
 
-let oauth = require('../auth/oauth.js');
-
-// Mock abacus-debug
-const loggerSpy = spy((arg) => arg);
-require.cache[require.resolve('abacus-debug')].exports = spy(() => loggerSpy);
+const reloadOauthModule = () => {
+  delete require.cache[require.resolve('../auth/oauth.js')];
+  return require('../auth/oauth.js');
+};
 
 describe('Oauth', () => {
-  context('when reading credentials from the environment', () => {
-    it('should not fail when they are not set', () => {
-      delete process.env.SERVICE_BROKER_CLIENT_ID;
-      delete process.env.SERVICE_BROKER_CLIENT_SECRET;
-      expect(oauth.init).to.not.throw(Error);
+  const sandbox = sinon.sandbox.create();
+
+  const wrapperStub = sandbox.stub();
+  wrapperStub.start = sandbox.stub();
+  const oauthStub = sandbox.stub(abacusOauth, 'cache');
+
+  const client = 'client';
+  const secret = 'secret';
+
+  after(() => sandbox.restore());
+
+  afterEach(() => sandbox.reset());
+
+  context('when all credentials are provided', () => {
+    const scopes = 'scope1 scope2';
+    const token1 = 'Bearer AAA';
+    const token2 = 'Bearer BBB';
+
+    beforeEach(() => {
+      process.env.SERVICE_BROKER_CLIENT_ID = client;
+      process.env.SERVICE_BROKER_CLIENT_SECRET = secret;
+      process.env.SERVICE_BROKER_CLIENT_SCOPES = scopes;
+    });
+
+    it('should call abacus oauth with the corresponding arguments', () => {
+      oauthStub.returns(wrapperStub);
+
+      reloadOauthModule();
+
+      expect(oauthStub.callCount).to.equal(2);
+      assert.calledWith(oauthStub, sinon.match.any, client, secret, scopes);
+      assert.calledWith(oauthStub, sinon.match.any, client, secret,
+        'clients.admin');
+    });
+
+    it('should return authorization headers', (done) => {
+      wrapperStub.start.yields();
+      wrapperStub.onFirstCall().returns(token1);
+      wrapperStub.onSecondCall().returns(token2);
+      oauthStub.returns(wrapperStub);
+
+      const oauth = reloadOauthModule();
+
+      oauth.init((err) => {
+        expect(err).to.equal(undefined);
+        expect(oauth.authHeader(oauth.SYSTEM_TOKEN))
+          .to.eql({ authorization: token1 });
+        expect(oauth.authHeader(oauth.CLIENT_REGISTRATION_TOKEN))
+          .to.eql({ authorization: token2 });
+        done();
+      });
+    });
+
+    it('should return system token by default', (done) => {
+      wrapperStub.start.yields();
+      wrapperStub.onFirstCall().returns(token1);
+      oauthStub.returns(wrapperStub);
+
+      const oauth = reloadOauthModule();
+
+      oauth.init((err) => {
+        expect(err).to.equal(undefined);
+        expect(oauth.authHeader()).to.eql({ authorization: token1 });
+        done();
+      });
+    });
+
+    it('should throw with invalid token identifier', (done) => {
+      wrapperStub.start.yields();
+      oauthStub.returns(wrapperStub);
+
+      const oauth = reloadOauthModule();
+
+      oauth.init((err) => {
+        expect(err).to.equal(undefined);
+        expect(() => oauth.authHeader('INVALID')).to.throw();
+        done();
+      });
+    });
+
+    it('should proxy the actual error from oauth', (done) => {
+      const errorMessage = 'some_error';
+      wrapperStub.start.yields(new Error(errorMessage));
+
+      oauthStub.returns(wrapperStub);
+
+      const oauth = reloadOauthModule();
+
+      oauth.init((err) => {
+        expect(err).to.be.instanceOf(Error);
+        expect(err.message).to.equal(errorMessage);
+        done();
+      });
     });
   });
 
-  context('when credentials are valid', () => {
-    const sampleToken = 'Bearer AAA';
+  context('when scopes are missing from the environment', () => {
+    it('should request the default ones', () => {
+      process.env.SERVICE_BROKER_CLIENT_ID = client;
+      process.env.SERVICE_BROKER_CLIENT_SECRET = secret;
+      delete process.env.SERVICE_BROKER_CLIENT_SCOPES;
+      oauthStub.returns(wrapperStub);
 
-    const mockAbacusOauth = (cacheResult, cacheStartCallbackResult) => {
-      const abacusOauthCacheSpy = spy(() => cacheResult);
-      abacusOauthCacheSpy.start = spy((cb) => cb(cacheStartCallbackResult));
-      const abacusOauthMock = extend({}, abacusOauth, {
-        cache: () => abacusOauthCacheSpy
-      });
-      require.cache[require.resolve('abacus-oauth')].exports = abacusOauthMock;
-      // reload oauth module to resolve the mock
-      delete require.cache[require.resolve('../auth/oauth.js')];
-      oauth = require('../auth/oauth.js');
-      return abacusOauthCacheSpy;
-    };
+      reloadOauthModule();
 
-    beforeEach(() => {
-      process.env.SERVICE_BROKER_CLIENT_ID = 'valid';
-      process.env.SERVICE_BROKER_CLIENT_SECRET = 'secret';
-    });
-
-    it('should return an authorization header', () => {
-      const abacusOauthSpy = mockAbacusOauth(sampleToken, undefined);
-
-      oauth.init(() => {
-        expect(oauth.authHeader())
-          .to.deep.equal({ authorization: sampleToken });
-        expect(abacusOauthSpy.called).to.equal(true);
-        expect(abacusOauthSpy.start.called).to.equal(true);
-        expect(loggerSpy.calledWithMatch('Successfully fetched'));
-      });
-    });
-
-    it('should return a token on each request', () => {
-      const abacusOauthSpy = mockAbacusOauth(sampleToken, undefined);
-
-      for (let callCount of [1, 2]) {
-        expect(oauth.authHeader())
-          .to.deep.equal({ authorization: sampleToken });
-        expect(abacusOauthSpy.callCount).to.equal(callCount);
-      }
-    });
-
-    it('should not fetch token in case of error', () => {
-      const abacusOauthSpy = mockAbacusOauth(undefined, 'some error');
-    
-      oauth.init(() => {
-        expect(oauth.authHeader()).to.be.equal(undefined);
-        expect(abacusOauthSpy.start.called).to.equal(true);
-      });
+      assert.calledWith(oauthStub, sinon.match.any,
+        client, secret, 'clients.admin');
+      assert.calledWith(oauthStub, sinon.match.any,
+        client, secret, 'abacus.usage.read abacus.usage.write');
     });
   });
 });


### PR DESCRIPTION
- add optional support for configurable broker client scopes
- support two tokens with different scopes, one for communication with the UAA and another for system calls
- `clients.admin` scope should be able to write clients on its own, so we don't need additionally `clients.write`