### PR TITLE
Do not skip account plugin tests execution

### DIFF
--- a/lib/plugins/account/src/test/test.js
+++ b/lib/plugins/account/src/test/test.js
@@ -1,19 +1,19 @@
 'use strict';
 
 // Plugin for an account management service.
-
 const _ = require('underscore');
 const request = require('abacus-request');
 const batch = require('abacus-batch');
+const oauth = require('abacus-oauth');
 const cluster = require('abacus-cluster');
+
+process.env.DB = process.env.DB || 'test';
 const dbclient = require('abacus-dbclient');
 const mappings = require('abacus-ext-plan-mappings');
-const oauth = require('abacus-oauth');
 
 const extend = _.extend;
 
 // Configure test db URL prefix
-process.env.DB = process.env.DB || 'test';
 
 const brequest = batch(request);
 
@@ -188,15 +188,17 @@ describe('abacus-ext-account-plugin', () => {
       });
   });
 
-  it('retrieves metering, rating and pricing plan ids', (done) => {
-    // Configure test db URL prefix
+  before((done) => {
     process.env.DB = process.env.DB || 'test';
-    accountManagement = require('..');
 
-    // Delete test dbs (plan and mappings) on the configured db server
     dbclient.drop(process.env.DB,
-      /^abacus-rating-plan|^abacus-pricing-plan|^abacus-metering-plan/,
-      done);
+      /^abacus-rating-plan|^abacus-pricing-plan|^abacus-metering-plan/, () => {
+        mappings.storeDefaultMappings(done);
+      });
+  });
+
+  it('retrieves metering, rating and pricing plan ids', (done) => {
+    accountManagement = require('..');
 
     process.env.SECURED = 'true';
     oauthspy.reset();
@@ -206,10 +208,6 @@ describe('abacus-ext-account-plugin', () => {
 
     // Listen on an ephemeral port
     const server = app.listen(0);
-
-    mappings.storeDefaultMappings(() => {
-      check(server.address().port, secured, done);
-    });
 
     let cbs = 0;
     const done1 = () => {
@@ -236,7 +234,6 @@ describe('abacus-ext-account-plugin', () => {
         expect(val.body).to.deep.equal('basic-object-storage');
         done1();
       });
-
 
     // Get rating plan id for the given org, resource type, and plan id
     brequest.get(
@@ -271,8 +268,5 @@ describe('abacus-ext-account-plugin', () => {
         expect(val.body).to.equal('object-pricing-basic');
         done1();
       });
-
   });
-
-
 });

--- a/tools/cmdline/src/cf-client-utils.js
+++ b/tools/cmdline/src/cf-client-utils.js
@@ -1,5 +1,7 @@
 'use strict';
 
+/* istanbul ignore file */
+
 const execute = require('./cmdline.js').execute;
 
 const getOrgId = (orgName) =>


### PR DESCRIPTION
- done was called before actually reaching the test cases and there was also a syntax error
- istanbul ignore the cf utils module